### PR TITLE
Implement annotation based command arguments

### DIFF
--- a/src/main/kotlin/tv/blademaker/killjoy/commands/game/AgentCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/game/AgentCommand.kt
@@ -18,14 +18,22 @@ package tv.blademaker.killjoy.commands.game
 import tv.blademaker.killjoy.Launcher
 import tv.blademaker.killjoy.framework.Category
 import tv.blademaker.killjoy.framework.ColorExtra
-import tv.blademaker.killjoy.framework.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.abs.Command
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 import tv.blademaker.killjoy.utils.Emojis
 import tv.blademaker.killjoy.utils.extensions.isInt
 
-@CommandProperties("agents", Category.Game, aliases = ["agent"])
+@CommandProperties(
+    name = "agents",
+    category = Category.Game,
+    aliases = ["agent"],
+    arguments = [
+        CommandArgument("agent_name:agent_id", "An agent name [jett] or agent id [1-13]", false),
+        CommandArgument("skill_button", "The button used to use this skill [q]", false)
+    ]
+)
 class AgentCommand : Command() {
 
     override val help: String = "Get information and statistics about a Valorant agent."
@@ -75,9 +83,4 @@ class AgentCommand : Command() {
             }.queue()
         }
     }
-
-    override val args: List<CommandArgument> = listOf(
-        CommandArgument("agent_name:agent_id", "An agent name [jett] or agent id [1-13]", false),
-        CommandArgument("skill_button", "The button used to use this skill [q]", false)
-    )
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/game/ArsenalCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/game/ArsenalCommand.kt
@@ -17,13 +17,20 @@ package tv.blademaker.killjoy.commands.game
 
 import tv.blademaker.killjoy.Launcher
 import tv.blademaker.killjoy.framework.Category
-import tv.blademaker.killjoy.framework.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.abs.Command
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 import tv.blademaker.killjoy.utils.Emojis
 
-@CommandProperties("arsenal", Category.Game, aliases = ["weapons", "weapon"])
+@CommandProperties(
+    name = "arsenal",
+    category = Category.Game,
+    aliases = ["weapons", "weapon"],
+    arguments = [
+        CommandArgument("weapon", "A valid Valorant weapon name [tacticalknife]", false)
+    ]
+)
 class ArsenalCommand : Command() {
     override suspend fun handle(ctx: CommandContext) {
         if (ctx.args.isEmpty()) {
@@ -47,8 +54,4 @@ class ArsenalCommand : Command() {
     }
 
     override val help: String = "Get information and statistics about a Valorant weapon or the entire aresenal."
-
-    override val args: List<CommandArgument> = listOf(
-        CommandArgument("weapon", "A valid Valorant weapon name [tacticalknife]", false)
-    )
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/game/MapsCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/game/MapsCommand.kt
@@ -17,12 +17,18 @@ package tv.blademaker.killjoy.commands.game
 
 import tv.blademaker.killjoy.Launcher
 import tv.blademaker.killjoy.framework.Category
-import tv.blademaker.killjoy.framework.CommandArgument
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.abs.Command
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 
-@CommandProperties("maps", Category.Game, aliases = ["map"])
+@CommandProperties(
+    name = "maps",
+    category = Category.Game,
+    aliases = ["map"],
+    arguments = [
+        CommandArgument("name", "Map name", false)
+    ])
 class MapsCommand : Command() {
     override suspend fun handle(ctx: CommandContext) {
         if (ctx.args.isEmpty()) {
@@ -45,8 +51,6 @@ class MapsCommand : Command() {
             }.queue()
         }
     }
-
-    override val args: List<CommandArgument> = listOf(CommandArgument("name", "Map name", false))
 
     override val help: String = "Get a list of maps or information about a specific map from Valorant"
 

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/game/SkillCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/game/SkillCommand.kt
@@ -18,14 +18,20 @@ package tv.blademaker.killjoy.commands.game
 import tv.blademaker.killjoy.Launcher
 import tv.blademaker.killjoy.framework.Category
 import tv.blademaker.killjoy.framework.ColorExtra
-import tv.blademaker.killjoy.framework.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.abs.Command
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 import tv.blademaker.killjoy.utils.Emojis
 import tv.blademaker.killjoy.utils.Utils
 
-@CommandProperties("skills", Category.Game, aliases = ["skill"])
+@CommandProperties(
+    name = "skills",
+    category = Category.Game,
+    aliases = ["skill"],
+    arguments = [
+        CommandArgument("skill_name", "A Skill name [shock-bolt]", true)
+    ])
 class SkillCommand : Command() {
     override suspend fun handle(ctx: CommandContext) {
         if (ctx.args.isEmpty()) return Utils.Commands.replyWrongUsage(ctx, this)
@@ -47,11 +53,5 @@ class SkillCommand : Command() {
         }.queue()
     }
 
-    override val args: List<CommandArgument> = listOf(
-        CommandArgument("skill_name", "A Skill name [shock-bolt]", true)
-    )
-
     override val help: String = "Get information about a skill from a Valorant agent"
-
-
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/game/TopCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/game/TopCommand.kt
@@ -15,17 +15,21 @@
 
 package tv.blademaker.killjoy.commands.game
 
-import tv.blademaker.killjoy.Launcher
 import tv.blademaker.killjoy.apis.riot.RiotAPI
 import tv.blademaker.killjoy.apis.riot.entities.Region
 import tv.blademaker.killjoy.framework.Category
-import tv.blademaker.killjoy.framework.CommandArgument
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.abs.Command
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 import tv.blademaker.killjoy.utils.Emojis
 
-@CommandProperties("top", Category.Game)
+@CommandProperties(
+    name = "top",
+    category = Category.Game,
+    arguments = [
+        CommandArgument("AP, BR, EU, KR, LATAM, NA", "Game region", true)
+    ])
 class TopCommand : Command() {
     override suspend fun handle(ctx: CommandContext) {
         if (ctx.args.isEmpty()) return ctx.reply("Specifies the game region. ${Region.values().map { it.name.toLowerCase() }}").queue()
@@ -48,10 +52,6 @@ class TopCommand : Command() {
             }
         }.queue()
     }
-
-    override val args = listOf(
-        CommandArgument(Region.values().joinToString(":") { it.name.toLowerCase() }, "Game region", true)
-    )
 
     override val help = "Retrieve the TOP 10 players by region."
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/info/HelpCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/info/HelpCommand.kt
@@ -18,12 +18,17 @@ package tv.blademaker.killjoy.commands.info
 import tv.blademaker.killjoy.Launcher
 import tv.blademaker.killjoy.framework.Category
 import tv.blademaker.killjoy.framework.ColorExtra
-import tv.blademaker.killjoy.framework.CommandArgument
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.abs.Command
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 
-@CommandProperties("help", Category.Information)
+@CommandProperties(
+    name = "help",
+    category = Category.Information,
+    arguments = [
+        CommandArgument("command", "The command you want to get information from.", false)
+    ])
 class HelpCommand : Command() {
     override suspend fun handle(ctx: CommandContext) {
         if (ctx.args.isEmpty()) {

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/info/HelpCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/info/HelpCommand.kt
@@ -73,16 +73,5 @@ class HelpCommand : Command() {
         }
     }
 
-    override val help: String
-        get() = HELP
-
-    override val args: List<CommandArgument>
-        get() = ARGS
-
-    companion object {
-        private const val HELP = "Get help on using the Killjoy commands"
-        private val ARGS = listOf(
-                CommandArgument("command", "The command you want to get information from.", false)
-        )
-    }
+    override val help = "Get help on using the Killjoy commands"
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/info/InviteCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/info/InviteCommand.kt
@@ -33,11 +33,9 @@ class InviteCommand : Command() {
             }.queue()
     }
 
-    override val help: String
-        get() = HELP
+    override val help = "Generate a invitation link for invite Killjoy to your servers."
 
     companion object {
-        const val HELP = "Generate a invitation link for invite Killjoy to your servers."
         const val INVITE = "https://discord.com/api/oauth2/authorize?client_id=706887214088323092&permissions=321600&scope=bot"
     }
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/info/PingCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/info/PingCommand.kt
@@ -31,4 +31,6 @@ class PingCommand : Command() {
                 "\uD83C\uDF10 Rest: `` %d ``\n\uD83D\uDDE8️ Gateway: `` %d ``",
                 ping, ctx.jda.gatewayPing)).await()
     }
+
+    override val help = "Pong!"
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/commands/misc/MemeCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/commands/misc/MemeCommand.kt
@@ -39,6 +39,5 @@ class MemeCommand : Command() {
         }.queue()
     }
 
-    override val help: String
-        get() = "Just Valorant related memes."
+    override val help = "Just Valorant related memes."
 }

--- a/src/main/kotlin/tv/blademaker/killjoy/framework/abs/Command.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/framework/abs/Command.kt
@@ -15,7 +15,7 @@
 package tv.blademaker.killjoy.framework.abs
 
 import net.dv8tion.jda.api.Permission
-import tv.blademaker.killjoy.framework.CommandArgument
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.annotations.CommandProperties
 import java.util.concurrent.atomic.AtomicInteger
@@ -53,8 +53,8 @@ abstract class Command {
     open val help: String
         get() = "Not help provided for this command."
 
-    open val args: List<CommandArgument>
-        get() = listOf()
+    open val args: Array<CommandArgument>
+        get() = props.arguments
 
     private val subCommands: MutableList<SubCommand> = mutableListOf()
     fun getSubCommands(): List<SubCommand> = subCommands

--- a/src/main/kotlin/tv/blademaker/killjoy/framework/abs/SubCommand.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/framework/abs/SubCommand.kt
@@ -15,7 +15,7 @@
 
 package tv.blademaker.killjoy.framework.abs
 
-import tv.blademaker.killjoy.framework.CommandArgument
+import tv.blademaker.killjoy.framework.annotations.CommandArgument
 import tv.blademaker.killjoy.framework.CommandContext
 import tv.blademaker.killjoy.framework.annotations.SubCommandProperties
 import java.util.concurrent.atomic.AtomicInteger
@@ -29,8 +29,8 @@ abstract class SubCommand(@JvmField val parent: Command) {
     open val help: String
         get() = "No help provided for this sub-command"
 
-    open val args: List<CommandArgument>
-        get() = listOf()
+    open val args: Array<CommandArgument>
+        get() = props.arguments
 
     @Throws(Exception::class)
     suspend fun execute(ctx: CommandContext) {

--- a/src/main/kotlin/tv/blademaker/killjoy/framework/annotations/CommandArgument.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/framework/annotations/CommandArgument.kt
@@ -12,9 +12,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  ******************************************************************************/
-package tv.blademaker.killjoy.framework
+package tv.blademaker.killjoy.framework.annotations
 
-data class CommandArgument(
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CommandArgument(
         val name: String,
         val info: String,
         val isRequired: Boolean = false

--- a/src/main/kotlin/tv/blademaker/killjoy/framework/annotations/CommandProperties.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/framework/annotations/CommandProperties.kt
@@ -24,6 +24,7 @@ annotation class CommandProperties(
         val category: Category,
         val isNsfw: Boolean = false,
         val aliases: Array<String> = [],
+        val arguments: Array<CommandArgument> = [],
         val cooldown: Cooldown = Cooldown(3),
         val userPermissions: Array<Permission> = [],
         val botPermissions: Array<Permission> = []

--- a/src/main/kotlin/tv/blademaker/killjoy/framework/annotations/SubCommandProperties.kt
+++ b/src/main/kotlin/tv/blademaker/killjoy/framework/annotations/SubCommandProperties.kt
@@ -18,5 +18,6 @@ package tv.blademaker.killjoy.framework.annotations
 @Retention(AnnotationRetention.RUNTIME)
 annotation class SubCommandProperties(
         val name: String,
-        val isNsfw: Boolean = false
+        val isNsfw: Boolean = false,
+        val arguments: Array<CommandArgument> = []
 )


### PR DESCRIPTION
In an effort to make Killjoy's internal code as close as possible to our main bot, [**HUGE**](https://hugebot.net), we have decided to have command arguments set within the command's properties as annotation.

### New implementation
```kotlin
@CommandProperties(
    . . .
    arguments = [
        CommandArgument("name", "info", true)
    ]
)
class MyCommand : Command() {
    . . .
}
```

### Old implementation
```kotlin
class MyCommand : Command() {
    override fun handle(ctx: CommandContext) {
        . . .
    }

    override val args: List<CommandArgument>
        get() = listOf(CommandArgument("name", "info", true))

    . . .
}
```